### PR TITLE
Conda-based install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ Dojo Clean Code
 
 This application requires python3 in order to work.
 
-Install dependencies:
+Install dependencies, through `conda`:
+
+```bash
+conda install --file requirements.txt
+```
+
+or through `pip3`
 
 ```bash
 pip3 install -r requirements.txt


### PR DESCRIPTION
This pull request amends the installation instructions in order
to provide the `conda` command equivalent to the existing
`pip3` one.